### PR TITLE
fix: make data method signature compatible with Illuminate\Http\Request

### DIFF
--- a/src/Requests/RegisterSubscriptionRequest.php
+++ b/src/Requests/RegisterSubscriptionRequest.php
@@ -21,9 +21,9 @@ class RegisterSubscriptionRequest extends FormRequest
     }
 
     /**
-     * @return array
+     * @return mixed
      */
-    public function data(): array
+    public function data($key = null, $default = null)
     {
         $content = json_decode($this->getContent(), true);
 


### PR DESCRIPTION
The signature for the `data` method on the `RegisterSubscriptionRequest` is inaccurate and caused the request not to materialise.  This means that the subscription is never written to the db and not confirmed with AWS leaving it in a perpetual pending state.